### PR TITLE
Get the 'nice' name of a controller

### DIFF
--- a/tv/ouya/console/api/OuyaController.hx
+++ b/tv/ouya/console/api/OuyaController.hx
@@ -150,6 +150,16 @@ class OuyaController
 		return _getDevice_func(a);
 	}
 	
+	private static var _getName_func:Dynamic;
+
+	public function getName():Dynamic
+	{
+		if (_getName_func == null)
+			_getName_func = openfl.utils.JNI.createMemberMethod("android.view.InputDevice", "getName", "()Ljava/lang/String;", true);
+		var a = new Array<Dynamic>();
+		a.push (getDevice());
+		return _getName_func(a);
+	}
 	
 	private static var _getDeviceId_func:Dynamic;
 


### PR DESCRIPTION
With this function, OuyaController.getName(), you can get a nice name of the controller, to identify the type. Examples are: "Microsoft X-box 360 pad", "OUYA Game Controller", ...
